### PR TITLE
Change single sid lookup to all sids at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*users.txt
 .idea
 *.pyc


### PR DESCRIPTION
Using a range and list comprehension this builds the command to lookup all sids in a range using a single call to rpcclient. This will increase speed significantly. Other changes include spaces for tabs and other PEP 8 compliant changes. Adding a .gitignore file as well.
